### PR TITLE
Add missing delete from table commands

### DIFF
--- a/scripts/import.sql
+++ b/scripts/import.sql
@@ -4,9 +4,12 @@
 pragma foreign_keys = 0;
 
 delete from inventory_sets;
+delete from inventory_minifigs;
 delete from inventory_parts;
 delete from inventories;
 delete from sets;
+delete from minifigs;
+delete from elements;
 delete from part_relationships;
 delete from parts;
 delete from part_categories;


### PR DESCRIPTION
Without these, when running make for the 2nd time, it fails with lots of errors like

tables/minifigs.csv:1660: INSERT failed: UNIQUE constraint failed: minifigs.fig_num